### PR TITLE
Add support for with_repeated_options and with_arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,37 +49,53 @@ Lino::CommandLineBuilder.for_command('ls')
     .with_flag('-a')
     .build
     .to_s
-    
+
 # => ls -l -a
-  
+
 # commands with options
 Lino::CommandLineBuilder.for_command('gpg')
     .with_option('--recipient', 'tobyclemson@gmail.com')
     .with_option('--sign', './doc.txt')
     .build
-    .to_s 
-    
+    .to_s
+
 # => gpg --recipient tobyclemson@gmail.com --sign ./doc.txt
-  
-# commands with arguments
+
+# commands with an option repeated multiple times (nil and empty option values are ignored)
+Lino::CommandLineBuilder.for_command('example.sh')
+    .with_repeated_option('--opt', ['file1.txt', nil, '', 'file2.txt'])
+    .build
+    .to_s
+
+# => example.sh --opt file1.txt --opt file2.txt
+
+# commands with arguments 
 Lino::CommandLineBuilder.for_command('diff')
     .with_argument('./file1.txt')
     .with_argument('./file2.txt')
     .build
-    .to_s 
-    
+    .to_s
+
 # => diff ./file1.txt ./file2.txt
-  
+
+# commands with an array of arguments (nil and empty arguments are ignored)
+Lino::CommandLineBuilder.for_command('diff')
+    .with_arguments(['./file1.txt', nil, '', './file2.txt'])
+    .build
+    .to_s
+
+# => diff ./file1.txt ./file2.txt
+
 # commands with custom option separator
 Lino::CommandLineBuilder.for_command('java')
     .with_option_separator(':')
     .with_option('-splash', './images/splash.jpg')
     .with_argument('./application.jar')
     .build
-    .to_s 
-    
+    .to_s
+
 # => java -splash:./images/splash.jpg ./application.jar
-  
+
 # commands using a subcommand style
 Lino::CommandLineBuilder.for_command('git')
     .with_flag('--no-pager')
@@ -88,9 +104,9 @@ Lino::CommandLineBuilder.for_command('git')
     end
     .build
     .to_s
-    
+
 # => git --no-pager log --since 2016-01-01
-  
+
 # commands with multiple levels of subcommand
 Lino::CommandLineBuilder.for_command('gcloud')
     .with_subcommand('sql')

--- a/lib/lino/command_line_builder.rb
+++ b/lib/lino/command_line_builder.rb
@@ -52,7 +52,12 @@ module Lino
     end
 
     def with_argument(argument)
-      with(arguments: @arguments.add({ components: [argument] }))
+      with(arguments: add_argument(argument))
+    end
+
+    def with_arguments(arguments)
+      arguments.each { |argument| add_argument(argument) }
+      with({})
     end
 
     def with_environment_variable(environment_variable, value)
@@ -96,6 +101,12 @@ module Lino
         option_separator: @option_separator,
         option_quoting: @option_quoting
       }
+    end
+
+    def add_argument(argument)
+      return @arguments if missing?(argument)
+
+      @arguments = @arguments.add({ components: [argument] })
     end
   end
 end

--- a/lib/lino/command_line_builder.rb
+++ b/lib/lino/command_line_builder.rb
@@ -2,10 +2,12 @@ require 'hamster'
 require_relative 'utilities'
 require_relative 'command_line'
 require_relative 'subcommand_builder'
+require_relative 'option_flag_mixin'
 
 module Lino
   class CommandLineBuilder
     include Lino::Utilities
+    include Lino::OptionFlagMixin
 
     class <<self
       def for_command(command)
@@ -41,28 +43,12 @@ module Lino
       )
     end
 
-    def with_option(switch, value, separator: nil, quoting: nil)
-      with(
-        switches: @switches.add(
-          {
-            components: [switch, value],
-            separator: separator,
-            quoting: quoting
-          }
-        )
-      )
-    end
-
     def with_option_separator(option_separator)
       with(option_separator: option_separator)
     end
 
     def with_option_quoting(character)
       with(option_quoting: character)
-    end
-
-    def with_flag(flag)
-      with(switches: @switches.add({ components: [flag] }))
     end
 
     def with_argument(argument)

--- a/lib/lino/option_flag_mixin.rb
+++ b/lib/lino/option_flag_mixin.rb
@@ -1,15 +1,36 @@
 module Lino
   module OptionFlagMixin
     def with_option(switch, value, separator: nil, quoting: nil)
-      with(switches: @switches.add({
-                                     components: [switch, value],
-                                     separator: separator,
-                                     quoting: quoting
-                                   }))
+      with(switches: add_option(switch, value, separator, quoting))
+    end
+
+    def with_repeated_option(switch, values, separator: nil, quoting: nil)
+      values.each do |value|
+        add_option(switch, value, separator, quoting)
+      end
+      with({})
     end
 
     def with_flag(flag)
-      with(switches: @switches.add({components: [flag]}))
+      with(switches: @switches.add({ components: [flag] }))
+    end
+
+    private
+
+    def add_option(switch, value, separator, quoting)
+      return @switches if missing?(value)
+
+      @switches = @switches.add(
+        {
+          components: [switch, value],
+          separator: separator,
+          quoting: quoting
+        }
+      )
+    end
+
+    def missing?(value)
+      value.nil? || (value.respond_to?(:empty?) && value.empty?)
     end
   end
 end

--- a/lib/lino/option_flag_mixin.rb
+++ b/lib/lino/option_flag_mixin.rb
@@ -1,0 +1,15 @@
+module Lino
+  module OptionFlagMixin
+    def with_option(switch, value, separator: nil, quoting: nil)
+      with(switches: @switches.add({
+                                     components: [switch, value],
+                                     separator: separator,
+                                     quoting: quoting
+                                   }))
+    end
+
+    def with_flag(flag)
+      with(switches: @switches.add({components: [flag]}))
+    end
+  end
+end

--- a/lib/lino/subcommand_builder.rb
+++ b/lib/lino/subcommand_builder.rb
@@ -1,9 +1,11 @@
 require 'hamster'
 require_relative 'utilities'
+require_relative 'option_flag_mixin'
 
 module Lino
   class SubcommandBuilder
     include Lino::Utilities
+    include Lino::OptionFlagMixin
 
     class <<self
       def for_subcommand(subcommand)
@@ -14,22 +16,6 @@ module Lino
     def initialize(subcommand: nil, switches: [])
       @subcommand = subcommand
       @switches = Hamster::Vector.new(switches)
-    end
-
-    def with_option(switch, value, separator: nil, quoting: nil)
-      with(
-        switches: @switches.add(
-          {
-            components: [switch, value],
-            separator: separator,
-            quoting: quoting
-          }
-        )
-      )
-    end
-
-    def with_flag(flag)
-      with(switches: @switches.add({ components: [flag] }))
     end
 
     def build(option_separator, option_quoting)

--- a/lib/lino/subcommand_builder.rb
+++ b/lib/lino/subcommand_builder.rb
@@ -6,52 +6,53 @@ module Lino
     include Lino::Utilities
 
     class <<self
-      def for_subcommand subcommand
+      def for_subcommand(subcommand)
         SubcommandBuilder.new(subcommand: subcommand)
       end
     end
 
-    def initialize(
-        subcommand: nil,
-        switches: [])
+    def initialize(subcommand: nil, switches: [])
       @subcommand = subcommand
       @switches = Hamster::Vector.new(switches)
     end
 
     def with_option(switch, value, separator: nil, quoting: nil)
-      with(switches: @switches.add({
-          components: [switch, value],
-          separator: separator,
-          quoting: quoting
-      }))
+      with(
+        switches: @switches.add(
+          {
+            components: [switch, value],
+            separator: separator,
+            quoting: quoting
+          }
+        )
+      )
     end
 
     def with_flag(flag)
-      with(switches: @switches.add({components: [flag]}))
+      with(switches: @switches.add({ components: [flag] }))
     end
 
     def build(option_separator, option_quoting)
       components = [
-          @subcommand,
-          map_and_join(@switches,
-              &(quote_with(option_quoting) >> join_with(option_separator)))
+        @subcommand,
+        map_and_join(
+          @switches,
+          &(quote_with(option_quoting) >> join_with(option_separator))
+        )
       ]
-
-      components
-          .reject { |item| item.empty? }
-          .join(' ')
+      components.reject(&:empty?).join(' ')
     end
 
     private
 
-    def with **replacements
+    def with(**replacements)
       SubcommandBuilder.new(**state.merge(replacements))
     end
 
     def state
       {
-          subcommand: @subcommand,
-          switches: @switches
+        subcommand: @subcommand,
+        switches: @switches
       }
     end
   end

--- a/spec/lino/command_line_builder_spec.rb
+++ b/spec/lino/command_line_builder_spec.rb
@@ -3,161 +3,279 @@ require 'spec_helper'
 RSpec.describe Lino::CommandLineBuilder do
   it 'includes the provided command in the resulting command line' do
     command_line = Lino::CommandLineBuilder
-        .for_command('command')
-        .build
+                   .for_command('command')
+                   .build
 
     expect(command_line.to_s).to eq('command')
   end
 
   it 'includes options after the command separated by a space by default' do
     command_line = Lino::CommandLineBuilder
-        .for_command('command-with-options')
-        .with_option('--opt1', 'val1')
-        .with_option('--opt2', 'val2')
-        .build
+                   .for_command('command-with-options')
+                   .with_option('--opt1', 'val1')
+                   .with_option('--opt2', 'val2')
+                   .build
 
     expect(command_line.to_s).to eq('command-with-options --opt1 val1 --opt2 val2')
   end
 
+  it 'does not include options without a value' do
+    command_line = Lino::CommandLineBuilder
+                   .for_command('command-with-options')
+                   .with_option('--opt1', 'val1')
+                   .with_option('--opt2', nil)
+                   .with_option('--opt3', '')
+                   .build
+
+    expect(command_line.to_s).to eq('command-with-options --opt1 val1')
+  end
+
+  it 'includes repeated options after the command separated by a space by default' do
+    command_line = Lino::CommandLineBuilder
+                   .for_command('command-with-options')
+                   .with_repeated_option('--opt', %w[val1 val2])
+                   .build
+
+    expect(command_line.to_s).to eq('command-with-options --opt val1 --opt val2')
+  end
+
   it 'uses the specified option separator when provided' do
     command_line = Lino::CommandLineBuilder
-        .for_command('command-with-option-separator')
-        .with_option_separator('=')
-        .with_option('--opt1', 'val1')
-        .with_option('--opt2', 'val2')
-        .build
+                   .for_command('command-with-option-separator')
+                   .with_option_separator('=')
+                   .with_option('--opt1', 'val1')
+                   .with_option('--opt2', 'val2')
+                   .build
 
     expect(command_line.to_s).to eq('command-with-option-separator --opt1=val1 --opt2=val2')
   end
 
+  it 'uses the specified option separator when provided for repeated options' do
+    command_line = Lino::CommandLineBuilder
+                   .for_command('command-with-options')
+                   .with_option_separator('=')
+                   .with_repeated_option('--opt', %w[val1 val2])
+                   .build
+
+    expect(command_line.to_s).to eq('command-with-options --opt=val1 --opt=val2')
+  end
+
   it 'allows the option separator to be overridden on an option by option basis' do
     command_line = Lino::CommandLineBuilder
-        .for_command('command-with-overridden-separator')
-        .with_option('--opt1', 'val1', separator: ':')
-        .with_option('--opt2', 'val2', separator: '~')
-        .with_option('--opt3', 'val3')
-        .build
+                   .for_command('command-with-overridden-separator')
+                   .with_option('--opt1', 'val1', separator: ':')
+                   .with_option('--opt2', 'val2', separator: '~')
+                   .with_option('--opt3', 'val3')
+                   .build
 
     expect(command_line.to_s)
-        .to(eq('command-with-overridden-separator --opt1:val1 --opt2~val2 --opt3 val3'))
+      .to(eq('command-with-overridden-separator --opt1:val1 --opt2~val2 --opt3 val3'))
+  end
+
+  it 'allows the option separator to be overridden on a repeated option by option basis' do
+    command_line = Lino::CommandLineBuilder
+                   .for_command('command-with-options')
+                   .with_repeated_option('--opt1', %w[val1 val2], separator: ':')
+                   .with_repeated_option('--opt2', %w[val3 val4], separator: '~')
+                   .with_repeated_option('--opt3', %w[val5 val6])
+                   .build
+
+    expect(command_line.to_s).to eq('command-with-options --opt1:val1 --opt1:val2 --opt2~val3 --opt2~val4 --opt3 val5 --opt3 val6')
   end
 
   it 'allows the option separator to be overridden for subcommands on an option by option basis' do
     command_line = Lino::CommandLineBuilder
-        .for_command('command-with-overridden-separator')
-        .with_subcommand('sub') do |sub|
-          sub
-            .with_option('--opt1', 'val1', separator: ':')
-            .with_option('--opt2', 'val2', separator: '~')
-            .with_option('--opt3', 'val3')
-        end
-        .build
+                   .for_command('command-with-overridden-separator')
+                   .with_subcommand('sub') do |sub|
+                     sub.with_option('--opt1', 'val1', separator: ':')
+                        .with_option('--opt2', 'val2', separator: '~')
+                        .with_option('--opt3', 'val3')
+                   end
+                   .build
 
     expect(command_line.to_s)
-        .to(eq('command-with-overridden-separator sub --opt1:val1 --opt2~val2 --opt3 val3'))
+      .to(eq('command-with-overridden-separator sub --opt1:val1 --opt2~val2 --opt3 val3'))
+  end
+
+  it 'allows the option separator to be overridden for subcommands on a repeated option by option basis' do
+    command_line = Lino::CommandLineBuilder
+                   .for_command('command-with-overridden-separator')
+                   .with_subcommand('sub') do |sub|
+                     sub.with_repeated_option('--opt1', %w[val1 val2], separator: ':')
+                        .with_repeated_option('--opt2', %w[val3 val4], separator: '~')
+                        .with_repeated_option('--opt3', %w[val5 val6])
+                   end
+                   .build
+
+    expect(command_line.to_s)
+      .to(eq('command-with-overridden-separator sub --opt1:val1 --opt1:val2 --opt2~val3 --opt2~val4 --opt3 val5 --opt3 val6'))
   end
 
   it 'uses the specified option quoting character when provided' do
     command_line = Lino::CommandLineBuilder
-        .for_command('command-with-quoting')
-        .with_option_quoting('"')
-        .with_option('--opt1', 'value1 with spaces')
-        .with_option('--opt2', 'value2 with spaces')
-        .build
+                   .for_command('command-with-quoting')
+                   .with_option_quoting('"')
+                   .with_option('--opt1', 'value1 with spaces')
+                   .with_option('--opt2', 'value2 with spaces')
+                   .build
 
     expect(command_line.to_s)
-        .to eq('command-with-quoting ' +
-            '--opt1 "value1 with spaces" ' +
-            '--opt2 "value2 with spaces"')
+      .to eq('command-with-quoting --opt1 "value1 with spaces" --opt2 "value2 with spaces"')
+  end
+
+  it 'uses the specified option quoting character with repeated options when provided' do
+    command_line = Lino::CommandLineBuilder
+                   .for_command('command-with-quoting')
+                   .with_option_quoting('"')
+                   .with_repeated_option('--opt', ['value with spaces', 'another value with spaces'])
+                   .build
+
+    expect(command_line.to_s)
+      .to eq('command-with-quoting --opt "value with spaces" --opt "another value with spaces"')
   end
 
   it 'allows the option quoting character to be overridden on an option by option basis' do
     command_line = Lino::CommandLineBuilder
-        .for_command('command-with-overridden-separator')
-        .with_option('--opt1', 'value 1', quoting: '"')
-        .with_option('--opt2', 'value 2', quoting: "'")
-        .with_option('--opt3', 'value3')
-        .build
+                   .for_command('command-with-overridden-quoting')
+                   .with_option('--opt1', 'value 1', quoting: '"')
+                   .with_option('--opt2', 'value 2', quoting: "'")
+                   .with_option('--opt3', 'value3')
+                   .build
 
     expect(command_line.to_s)
-        .to(eq('command-with-overridden-separator ' +
-            '--opt1 "value 1" ' +
-            '--opt2 \'value 2\' ' +
-            '--opt3 value3'))
+      .to(eq("command-with-overridden-quoting --opt1 \"value 1\" --opt2 'value 2' --opt3 value3"))
+  end
+
+  it 'allows the option quoting character to be overridden on a repeated option by option basis' do
+    command_line = Lino::CommandLineBuilder
+                   .for_command('command-with-overridden-quoting')
+                   .with_repeated_option('--opt1', %w[val1 val2], quoting: '"')
+                   .with_repeated_option('--opt2', %w[val3 val4], quoting: "'")
+                   .build
+
+    expect(command_line.to_s).to eq("command-with-overridden-quoting --opt1 \"val1\" --opt1 \"val2\" --opt2 'val3' --opt2 'val4'")
   end
 
   it 'allows the option quoting character to be overridden for subcommands on an option by option basis' do
     command_line = Lino::CommandLineBuilder
-        .for_command('command-with-overridden-separator')
-        .with_subcommand('sub') do |sub|
-          sub
-              .with_option('--opt1', 'value 1', quoting: '"')
-              .with_option('--opt2', 'value 2', quoting: "'")
-              .with_option('--opt3', 'value3')
-        end
-        .build
+                   .for_command('command-with-overridden-quoting')
+                   .with_subcommand('sub') do |sub|
+                     sub
+                       .with_option('--opt1', 'value 1', quoting: '"')
+                       .with_option('--opt2', 'value 2', quoting: "'")
+                       .with_option('--opt3', 'value3')
+                   end
+                   .build
 
     expect(command_line.to_s)
-        .to(eq('command-with-overridden-separator sub ' +
-            '--opt1 "value 1" ' +
-            '--opt2 \'value 2\' ' +
-            '--opt3 value3'))
+      .to(eq("command-with-overridden-quoting sub --opt1 \"value 1\" --opt2 'value 2' --opt3 value3"))
+  end
+
+  it 'allows the option quoting character to be overridden for subcommands on a repeated option by option basis' do
+    command_line = Lino::CommandLineBuilder
+                   .for_command('command-with-overridden-quoting')
+                   .with_subcommand('sub') do |sub|
+                     sub.with_repeated_option('--opt1', %w[val1 val2], quoting: '"')
+                        .with_repeated_option('--opt2', %w[val3 val4], quoting: "'")
+                        .with_repeated_option('--opt3', %w[val5 val6])
+                   end
+                   .build
+
+    expect(command_line.to_s)
+      .to(eq("command-with-overridden-quoting sub --opt1 \"val1\" --opt1 \"val2\" --opt2 'val3' --opt2 'val4' --opt3 val5 --opt3 val6"))
   end
 
   it 'treats option specific separators as higher precedence than the global option separator' do
     command_line = Lino::CommandLineBuilder
-        .for_command('command-with-overridden-separator')
-        .with_option_separator('=')
-        .with_option('--opt1', 'val1', separator: ':')
-        .with_option('--opt2', 'val2', separator: '~')
-        .with_option('--opt3', 'val3')
-        .build
+                   .for_command('command-with-overridden-separator')
+                   .with_option_separator('=')
+                   .with_option('--opt1', 'val1', separator: ':')
+                   .with_option('--opt2', 'val2', separator: '~')
+                   .with_option('--opt3', 'val3')
+                   .build
 
     expect(command_line.to_s)
-        .to(eq('command-with-overridden-separator --opt1:val1 --opt2~val2 --opt3=val3'))
+      .to(eq('command-with-overridden-separator --opt1:val1 --opt2~val2 --opt3=val3'))
+  end
+
+  it 'treats repeated option specific separators as higher precedence than the global option separator' do
+    command_line = Lino::CommandLineBuilder
+                   .for_command('command-with-overridden-separator')
+                   .with_option_separator('=')
+                   .with_repeated_option('--opt1', %w[val1 val2], separator: ':')
+                   .with_repeated_option('--opt2', %w[val3 val4], separator: '~')
+                   .with_repeated_option('--opt3', %w[val5 val6])
+                   .build
+
+    expect(command_line.to_s)
+      .to(eq('command-with-overridden-separator --opt1:val1 --opt1:val2 --opt2~val3 --opt2~val4 --opt3=val5 --opt3=val6'))
+  end
+
+  it 'allows options and repeated options to be used together' do
+    command_line = Lino::CommandLineBuilder
+                   .for_command('command-with-options')
+                   .with_repeated_option('--opt1', %w[val1 val2])
+                   .with_option('--opt2', 'val3')
+                   .build
+
+    expect(command_line.to_s).to eq('command-with-options --opt1 val1 --opt1 val2 --opt2 val3')
+  end
+
+  it 'allows options and repeated option to work together for subcommands' do
+    command_line = Lino::CommandLineBuilder
+                   .for_command('command-with-options')
+                   .with_subcommand('sub') do |sub|
+                     sub.with_repeated_option('--opt1', %w[val1 val2], quoting: '"')
+                        .with_option('--opt2', 'val3')
+                   end
+                   .build
+
+    expect(command_line.to_s)
+      .to(eq('command-with-options sub --opt1 "val1" --opt1 "val2" --opt2 val3'))
   end
 
   it 'includes flags after the command' do
     command_line = Lino::CommandLineBuilder
-        .for_command('command-with-flags')
-        .with_flag('--verbose')
-        .with_flag('-h')
-        .build
+                   .for_command('command-with-flags')
+                   .with_flag('--verbose')
+                   .with_flag('-h')
+                   .build
 
     expect(command_line.to_s).to eq('command-with-flags --verbose -h')
   end
 
   it 'includes args after the command and all flags and options' do
     command_line = Lino::CommandLineBuilder
-        .for_command('command-with-args')
-        .with_flag('-v')
-        .with_option('--opt', 'val')
-        .with_argument('path/to/file.txt')
-        .build
+                   .for_command('command-with-args')
+                   .with_flag('-v')
+                   .with_option('--opt', 'val')
+                   .with_argument('path/to/file.txt')
+                   .build
 
     expect(command_line.to_s).to eq('command-with-args -v --opt val path/to/file.txt')
   end
 
   it 'includes environment variables before the command' do
     command_line = Lino::CommandLineBuilder
-        .for_command('command-with-environment-variables')
-        .with_environment_variable('ENV_VAR1', 'VAL1')
-        .with_environment_variable('ENV_VAR2', 'VAL2')
-        .with_environment_variable('ENV_VAR3', '"[1,2,3]"')
-        .build
+                   .for_command('command-with-environment-variables')
+                   .with_environment_variable('ENV_VAR1', 'VAL1')
+                   .with_environment_variable('ENV_VAR2', 'VAL2')
+                   .with_environment_variable('ENV_VAR3', '"[1,2,3]"')
+                   .build
 
     expect(command_line.to_s).to(
-        eq('ENV_VAR1="VAL1" ENV_VAR2="VAL2" ENV_VAR3="\"[1,2,3]\"" command-with-environment-variables'))
+      eq('ENV_VAR1="VAL1" ENV_VAR2="VAL2" ENV_VAR3="\"[1,2,3]\"" command-with-environment-variables')
+    )
   end
 
   it 'includes command options and flags before subcommands' do
     command_line = Lino::CommandLineBuilder
-        .for_command('command-with-subcommand')
-        .with_flag('-v')
-        .with_option('--opt', 'val')
-        .with_subcommand('sub1')
-        .with_subcommand('sub2')
-        .build
+                   .for_command('command-with-subcommand')
+                   .with_flag('-v')
+                   .with_option('--opt', 'val')
+                   .with_subcommand('sub1')
+                   .with_subcommand('sub2')
+                   .build
 
     expect(command_line.to_s)
       .to eq('command-with-subcommand -v --opt val sub1 sub2')
@@ -165,35 +283,31 @@ RSpec.describe Lino::CommandLineBuilder do
 
   it 'includes args after all subcommands' do
     command_line = Lino::CommandLineBuilder
-        .for_command('command-with-subcommand-and-args')
-        .with_subcommand('sub1')
-        .with_argument('path/to/file.txt')
-        .with_subcommand('sub2')
-        .build
+                   .for_command('command-with-subcommand-and-args')
+                   .with_subcommand('sub1')
+                   .with_argument('path/to/file.txt')
+                   .with_subcommand('sub2')
+                   .build
 
     expect(command_line.to_s)
-        .to eq('command-with-subcommand-and-args sub1 sub2 path/to/file.txt')
+      .to eq('command-with-subcommand-and-args sub1 sub2 path/to/file.txt')
   end
 
   it 'includes subcommand options and flags with the subcommand' do
     command_line = Lino::CommandLineBuilder
-        .for_command('command-with-subcommands-with-options')
-        .with_subcommand('sub1') do |sub1|
-          sub1
-              .with_flag('-1')
-              .with_option('--opt1', 'val1')
-        end
-        .with_subcommand('sub2') do |sub2|
-          sub2
-              .with_option('--opt2', 'val2')
-              .with_flag('-2')
-        end
-        .with_option('--opt', 'val')
-        .build
+                   .for_command('command-with-subcommands-with-options')
+                   .with_subcommand('sub1') do |sub1|
+                     sub1.with_flag('-1')
+                         .with_option('--opt1', 'val1')
+                   end
+                   .with_subcommand('sub2') do |sub2|
+                     sub2.with_option('--opt2', 'val2')
+                         .with_flag('-2')
+                   end
+                   .with_option('--opt', 'val')
+                   .build
 
     expect(command_line.to_s)
-        .to eq('command-with-subcommands-with-options --opt val ' +
-            'sub1 -1 --opt1 val1 ' +
-            'sub2 --opt2 val2 -2')
+      .to eq('command-with-subcommands-with-options --opt val sub1 -1 --opt1 val1 sub2 --opt2 val2 -2')
   end
 end

--- a/spec/lino/command_line_builder_spec.rb
+++ b/spec/lino/command_line_builder_spec.rb
@@ -255,6 +255,40 @@ RSpec.describe Lino::CommandLineBuilder do
     expect(command_line.to_s).to eq('command-with-args -v --opt val path/to/file.txt')
   end
 
+  it 'includes multiple args after the command and all flags and options' do
+    command_line = Lino::CommandLineBuilder
+                   .for_command('command-with-args')
+                   .with_flag('-v')
+                   .with_option('--opt', 'val')
+                   .with_arguments(%w[path/to/file1.txt path/to/file2.txt])
+                   .build
+
+    expect(command_line.to_s).to eq('command-with-args -v --opt val path/to/file1.txt path/to/file2.txt')
+  end
+
+  it 'ignores empty args when processing arguments' do
+    command_line = Lino::CommandLineBuilder
+                   .for_command('command-with-args')
+                   .with_flag('-v')
+                   .with_option('--opt', 'val')
+                   .with_arguments(['path/to/file1.txt', '', nil, 'path/to/file2.txt'])
+                   .build
+
+    expect(command_line.to_s).to eq('command-with-args -v --opt val path/to/file1.txt path/to/file2.txt')
+  end
+
+  it 'allows multiple args and args to be used together' do
+    command_line = Lino::CommandLineBuilder
+                   .for_command('command-with-args')
+                   .with_flag('-v')
+                   .with_option('--opt', 'val')
+                   .with_arguments(%w[path/to/file1.txt path/to/file2.txt])
+                   .with_argument('another_file.txt')
+                   .build
+
+    expect(command_line.to_s).to eq('command-with-args -v --opt val path/to/file1.txt path/to/file2.txt another_file.txt')
+  end
+
   it 'includes environment variables before the command' do
     command_line = Lino::CommandLineBuilder
                    .for_command('command-with-environment-variables')


### PR DESCRIPTION
Per our discussion on the RubyTerraform RFC - add support for `with_repeated_options` and `with_arguments` as well as incorporate the conditional logic into with_option to ignore switches with no value.